### PR TITLE
Improve the pre-test function to minimize the SikuliX java window

### DIFF
--- a/!include/util.sikuli/util.py
+++ b/!include/util.sikuli/util.py
@@ -16,7 +16,8 @@ def pre_test():
     assert(not os.path.exists(os.path.join(start_menu, "OneDrive (2).lnk")))
 
     # Hide the SikuliX java window.
-    java_cmd = App().focus("java")
+    App().focus("java.exe")
+    java_cmd = App().focus("java.exe") # Try this twice to gain the focus of the java window.
     if java_cmd.isValid():
         type(Key.DOWN, Key.WIN)
 


### PR DESCRIPTION
The java window for SikuliX is not minimized correctly sometimes, especially for command-line based apps. The reason might be that the whole VM session is not in focus. Now the code will do `App().focus("java.exe")` twice to make sure the focus is obtained.

I tested using nodejs-lts and temurin-lts and they looked good.